### PR TITLE
Add a null check for a method return result that may return null

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -716,6 +716,10 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         }
 
         Manifest manifest = parsePluginManifest(hpiResUrl);
+        if (manifest == null) {
+            return;
+        }
+        
         String dependencySpec = manifest.getMainAttributes().getValue("Plugin-Dependencies");
         if (dependencySpec != null) {
             String[] dependencyTokens = dependencySpec.split(",");


### PR DESCRIPTION
In file PluginManager.java the parsePluginManifest method may return null. In other parts of the code (https://github.com/jenkinsci/jenkins/blob/7aad67832442b8cd1dfaf363a3630d2687ddf3e3/core/src/main/java/hudson/PluginManager.java#L868), the return value was checked for null. But the null check is missing in this part of the code. 

The fix just adds the missing null check in the code.

### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF): Project Alpha-Omega. Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed - to improve global software supply chain security.

The bug is found by running the iCR tool by OpenRefactory, Inc. and then manually triaging the results.